### PR TITLE
Use a custom header to specify the model

### DIFF
--- a/app/controllers/concerns/integrator/hyrax/works_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/works_behavior.rb
@@ -69,7 +69,11 @@ module Integrator
 
       private
         def set_work_klass
-          @work_klass = WillowSword.config.work_models.first.singularize.classify.constantize
+          if headers[:hyrax_work_model] && WillowSword.config.work_models.include?(headers[:hyrax_work_model])
+            @work_klass = headers[:hyrax_work_model].constantize
+          else
+            @work_klass = WillowSword.config.work_models.first.constantize
+          end
         end
 
         # @param [Hash] attrs the attributes to put in the environment

--- a/app/controllers/concerns/willow_sword/fetch_headers.rb
+++ b/app/controllers/concerns/willow_sword/fetch_headers.rb
@@ -14,6 +14,7 @@ module WillowSword
       fetch_in_progress
       fetch_on_behalf_of
       fetch_slug
+      fetch_hyrax_work_model
     end
 
     def fetch_content_type
@@ -56,6 +57,11 @@ module WillowSword
     def fetch_slug
       @headers[:slug] = request.headers.fetch('Slug', nil)
       # puts "Slug: #{@headers[:slug]}"
+    end
+    
+    # @todo add custom header for model HyraxWorkModel
+    def fetch_hyrax_work_model
+      @headers[:hyrax_work_model] = request.headers.fetch('Hyrax-Work-Model', nil)
     end
 
   end

--- a/app/controllers/willow_sword/works_controller.rb
+++ b/app/controllers/willow_sword/works_controller.rb
@@ -2,7 +2,7 @@ require_dependency "willow_sword/application_controller"
 
 module WillowSword
   class WorksController < ApplicationController
-    before_action :set_work_klass
+    before_action :fetch_headers, :set_work_klass
     attr_reader :collection_id, :headers, :file, :dir, :data_content_type, :attributes, :files, :object, :file_ids, :work_klass
     include WillowSword::FetchHeaders
     include WillowSword::MultipartDeposit
@@ -34,7 +34,6 @@ module WillowSword
     private
 
     def validate_request
-      fetch_headers
       # Choose based on content type
       case request.content_type
       when 'multipart/related'


### PR DESCRIPTION
I thought it would be useful to be able to specify the model as part of the deposit. Rather than use an arbitrary metadata field, I've added a  custom header called Hyrax-Work-Model.

When a model is supplied, it is checked against `config.work_models` and if it's included in there, a work of that class is created.

If it's blank, or the model isn't in the config, it's ignored and the default value (the first in `config.work_models`) is used.