### PR TITLE
add support for text/xml

### DIFF
--- a/app/controllers/concerns/willow_sword/process_deposit.rb
+++ b/app/controllers/concerns/willow_sword/process_deposit.rb
@@ -65,7 +65,7 @@ module WillowSword
         # process zip
         # puts 'process zip'
         process_zip
-      when 'application/xml'
+      when 'application/xml', 'text/xml'
         # process xml
         # puts 'process xml'
         process_xml


### PR DESCRIPTION
I've been having trouble with my content-type getting automatically set to `text\xml` so I've added support for it.