### PR TITLE
Fixes for ORA related issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ spec/dummy/db/*.sqlite3
 spec/dummy/db/*.sqlite3-journal
 spec/dummy/log/*.log
 spec/dummy/tmp/
+
+# Idea files
+*.iml

--- a/app/controllers/concerns/integrator/hyrax/file_sets_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/file_sets_behavior.rb
@@ -14,6 +14,13 @@ module Integrator
       end
 
       def create_file_set
+        # Required to allow inline creation for active jobs
+        # in development mode.
+        # https://github.com/samvera/hyrax/issues/3128
+        if Rails.env == 'development'
+          [::Noid::Rails::Service.new.minter.mint,
+           ::Noid::Rails::Service.new.minter.mint]
+        end
         @file_set = FileSet.create
         @current_user = User.batch_user unless @current_user.present?
         @actor = file_set_actor.new(@file_set, @current_user)

--- a/app/controllers/concerns/integrator/hyrax/works_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/works_behavior.rb
@@ -111,6 +111,7 @@ module Integrator
           else
            @attributes.merge(file_attributes)
           end
+          @attributes
         end
 
         def file_attributes

--- a/app/controllers/concerns/integrator/hyrax/works_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/works_behavior.rb
@@ -57,6 +57,13 @@ module Integrator
       def create_work
         attrs = create_attributes
         @object = @work_klass.new
+        # Required to allow inline creation in active jobs
+        # in development mode.
+        # https://github.com/samvera/hyrax/issues/3128
+        if Rails.env == 'development'
+          [::Noid::Rails::Service.new.minter.mint,
+           ::Noid::Rails::Service.new.minter.mint]
+        end
         work_actor.create(environment(attrs))
       end
 

--- a/app/controllers/concerns/integrator/hyrax/works_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/works_behavior.rb
@@ -118,7 +118,6 @@ module Integrator
           else
            @attributes.merge(file_attributes)
           end
-          @attributes
         end
 
         def file_attributes

--- a/app/controllers/concerns/integrator/hyrax/works_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/works_behavior.rb
@@ -64,6 +64,7 @@ module Integrator
           [::Noid::Rails::Service.new.minter.mint,
            ::Noid::Rails::Service.new.minter.mint]
         end
+        byebug
         work_actor.create(environment(attrs))
       end
 

--- a/app/controllers/concerns/willow_sword/extract_metadata.rb
+++ b/app/controllers/concerns/willow_sword/extract_metadata.rb
@@ -6,10 +6,12 @@ module WillowSword
     def extract_metadata(file_path)
       @attributes = nil
       if WillowSword.config.xml_mapping_create == 'MODS'
-        xw = WillowSword::ModsCrosswalk.new(file_path)
+        xw = WillowSword::ModsCrosswalk.new(file_path, @headers)
         xw.map_xml
+        @metadata = xw.metadata
+        @mapped_metadata = {}
         assign_mods_to_model
-        @attributes = xw.mapped_metadata
+        @attributes = @mapped_metadata
       else
         xw = WillowSword::DcCrosswalk.new(file_path)
         xw.map_xml

--- a/app/controllers/concerns/willow_sword/process_request.rb
+++ b/app/controllers/concerns/willow_sword/process_request.rb
@@ -51,11 +51,7 @@ module WillowSword
       bag_path = File.join(@dir, 'bag')
       # validate or create bag
       bag = WillowSword::BagPackage.new(contents_path, bag_path)
-      if @headers[:filename].present?
-        @metadata_file = File.join(bag.package.data_dir, @headers[:filename])
-      else
-        @metadata_file = File.join(bag.package.data_dir, 'metadata.xml')
-      end
+      @metadata_file = File.join(bag.package.data_dir, 'metadata.xml')
       @files = bag.package.bag_files - [@metadata_file]
     end
 

--- a/app/controllers/concerns/willow_sword/process_request.rb
+++ b/app/controllers/concerns/willow_sword/process_request.rb
@@ -51,7 +51,11 @@ module WillowSword
       bag_path = File.join(@dir, 'bag')
       # validate or create bag
       bag = WillowSword::BagPackage.new(contents_path, bag_path)
-      @metadata_file = File.join(bag.package.data_dir, 'metadata.xml')
+      if @headers[:filename].present?
+        @metadata_file = File.join(bag.package.data_dir, @headers[:filename])
+      else
+        @metadata_file = File.join(bag.package.data_dir, 'metadata.xml')
+      end
       @files = bag.package.bag_files - [@metadata_file]
     end
 

--- a/app/controllers/willow_sword/file_sets_controller.rb
+++ b/app/controllers/willow_sword/file_sets_controller.rb
@@ -55,7 +55,13 @@ module WillowSword
           @error = WillowSword::Error.new(message)
           return false
         end
-        return false unless parse_metadata(@metadata_file, false)
+        if File.exist?(@metadata_file)
+          return false unless parse_metadata(@metadata_file, false)
+        else
+          # Binary filesets can be created without metadata
+          @attributes = Hash.new
+          @attributes['file_name'] = @headers[:filename]
+        end
         create_file_set
         true
       end

--- a/lib/willow_sword/mods_crosswalk.rb
+++ b/lib/willow_sword/mods_crosswalk.rb
@@ -1,8 +1,9 @@
 module WillowSword
   class ModsCrosswalk
     attr_reader :metadata, :model, :mods, :mapped_metadata
-    def initialize(src_file)
+    def initialize(src_file, headers)
       @src_file = src_file
+      @headers = headers
       @mods = nil
       @metadata = {}
       @mapped_metadata = {}
@@ -196,7 +197,7 @@ module WillowSword
 
     def get_headers
       if @headers.any?
-        @metadata['headers'] = stringify_keys(@headers)
+        @metadata['headers'] = @headers.stringify_keys
       end
     end
 


### PR DESCRIPTION
Not all of these changes, I expect, will be acceptable.

The change to works_behaviour.rb transform_attributes() is a hack because permitted attributes is not set properly.

The change to extract_metadata.rb is because I suspect that the underlying relationship between code and object may have changed when you separated out mods_to_model. I think.

The others are relatively straightforward.