### PR TITLE
Feature/ora customizations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,4 @@ group :test do
   gem 'factory_girl_rails' # , '~> 4.0'
   gem 'shoulda-matchers' #, '~> 3.1'
 end
+gem 'iso-639'

--- a/app/services/willow_sword/assign_mets_to_model.rb
+++ b/app/services/willow_sword/assign_mets_to_model.rb
@@ -134,7 +134,7 @@ module WillowSword
       item_desc_keys = {
         # item_description_and_embargo_information
         'pmid' => 'identifier_pmid',
-        # 'pubs_id' => 'identifier_pubs_identifier',
+        'pubs_id' => 'identifier_pubs_identifier',
         'tinypid' => 'tinypid',
         'uuid' => 'identifier_uuid'
       }

--- a/app/services/willow_sword/assign_mets_to_model.rb
+++ b/app/services/willow_sword/assign_mets_to_model.rb
@@ -1,3 +1,4 @@
+require 'iso-639'
 module WillowSword
   module AssignMetsToModel
 
@@ -197,7 +198,27 @@ module WillowSword
     def assign_language
       # Language
       unless @metadata.fetch('language', []).blank?
-        @mapped_metadata['language'] = Array(@metadata['language'])
+        languages = Array(@metadata['language'])
+        # strip invalid languages
+        validated_languages = languages.map { |lang| validate_language(lang) }.compact
+        @mapped_metadata['language'] = validated_languages
+      end
+    end
+
+    def validate_language(language)
+      # Validate language against ISO-639
+      # Params:
+      #   language(string): unvalidated language string
+      # Returns:
+      #   validated_language (string): validated language string
+      @language_match = ISO_639.find_by_english_name(language)
+      if @language_match.present?
+        return @language_match.english_name
+      end
+      @language_search = ISO_639.search(language)
+      if @language_search.present?
+        # Look for the language on a best-guess basis
+        return @language_search[0].english_name
       end
     end
 

--- a/app/services/willow_sword/assign_mets_to_model.rb
+++ b/app/services/willow_sword/assign_mets_to_model.rb
@@ -154,11 +154,7 @@ module WillowSword
       ids.each do |key,vals|
         next unless Array(vals).any?
         if pub_keys.include?(key)
-          if key == 'doi'
-            pub_attrs[pub_keys[key]] = Array(vals)
-          else
-            pub_attrs[pub_keys[key]] = Array(vals).first
-          end
+          pub_attrs[pub_keys[key]] = Array(vals).first
         elsif item_desc_keys.include?(key)
           item_desc_attrs[item_desc_keys[key]] = Array(vals).first
         elsif admin_keys.include?(key)

--- a/app/services/willow_sword/crosswalk_to_mods.rb
+++ b/app/services/willow_sword/crosswalk_to_mods.rb
@@ -171,7 +171,7 @@ module WillowSword
       # identifier fields
       fields = {
         'identifier_pmid' => ['item_description_and_embargo_information', 'pmid'],
-        # 'identifier_pubs_identifier' => ['item_description_and_embargo_information', 'pubs_id'],
+        'identifier_pubs_identifier' => ['item_description_and_embargo_information', 'pubs_id'],
         'tinypid' => ['item_description_and_embargo_information', 'tinypid'],
         'identifier_uuid' => ['item_description_and_embargo_information', 'uuid'],
         'identifier_source_identifier' => ['admin_information', 'source_identifier'],

--- a/app/services/willow_sword/crosswalk_to_mods.rb
+++ b/app/services/willow_sword/crosswalk_to_mods.rb
@@ -166,6 +166,8 @@ module WillowSword
     end
 
     def add_identifier
+      # export pid
+      @doc.root << create_node('mods:identifier', @work.id, {'type' => 'pid'})
       # identifier fields
       fields = {
         'identifier_pmid' => ['item_description_and_embargo_information', 'pmid'],

--- a/app/services/willow_sword/crosswalk_to_ora.rb
+++ b/app/services/willow_sword/crosswalk_to_ora.rb
@@ -28,6 +28,9 @@ module WillowSword
       translated_terms.each do |model_key, xml_tag|
         @doc.root << create_node(xml_tag, Array(@fileset[model_key])[0]) unless Array(@fileset[model_key]).blank?
       end
+      # add the FileSet ID so that downstream users can map
+      # files to Hyrax filesets for downloads
+      @doc.root << create_node('ora:filesetId', @fileset.id)
       unless @fileset['file_made_available_date'].blank?
         node = create_node('ali:free_to_read')
         add_attributes(node, {'start_date' => @fileset['file_made_available_date']})

--- a/willow_sword.iml
+++ b/willow_sword.iml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="RUBY_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="RailsFacetType" name="Ruby on Rails">
+      <configuration>
+        <RAILS_FACET_CONFIG_ID NAME="RAILS_FACET_SUPPORT_REMOVED" VALUE="false" />
+        <RAILS_FACET_CONFIG_ID NAME="RAILS_TESTS_SOURCES_PATCHED" VALUE="true" />
+        <RAILS_FACET_CONFIG_ID NAME="RAILS_FACET_APPLICATION_ROOT" VALUE="$MODULE_DIR$/spec/dummy" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/spec/dummy/test" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/spec/dummy/spec" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/spec/dummy/.bundle" />
+      <excludeFolder url="file://$MODULE_DIR$/spec/dummy/components" />
+      <excludeFolder url="file://$MODULE_DIR$/spec/dummy/public/system" />
+      <excludeFolder url="file://$MODULE_DIR$/spec/dummy/tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/spec/dummy/vendor/bundle" />
+      <excludeFolder url="file://$MODULE_DIR$/spec/dummy/vendor/cache" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="RModuleSettingsStorage">
+    <LOAD_PATH number="0" />
+    <I18N_FOLDERS number="1" string0="$MODULE_DIR$/spec/dummy/config/locales" />
+  </component>
+</module>


### PR DESCRIPTION
Some use cases, e.g. downloading files, require a fileset ID or a pid in the metadata. Therefore
the METS metadata (and binary fileset metadata) should output
a filesetID if this is available, and a pid if this is set.

At present, there is no need to crosswalk this value, as it should only be
generated on export, not set on ingest. Therefore it can be automatically generated
when the relevant metadata is viewed, but not otherwise processed.

This update adds the output in the form ora:filesetId, as documented
in the sample METS documentation (and sample binary fileset metadata
example), and mods:identifier[@type='pid'].

This update also reinstates identifier_pubs_identifier which was wrongly omitted from the
Hyrax version submitted for testing (and as a result suppressed in the crosswalks). 

https://github.com/tomwrobel/ora_data_model/issues/45
https://github.com/tomwrobel/ora_data_model/issues/46
and

https://github.com/tomwrobel/ora_data_model/issues/48